### PR TITLE
feat: Add support for binary content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Main features are:
 - Automatically convert `format: 'date-time'` to JS `Date`
 - Handle **API Key**, **HTTP Config** and **OAuth2**<sup>1</sup> auth security schemes
 - JSDoc for schemas and operations
+- Non JSON content type support
 - And more...
 
 > <sup>1</sup>: OAuth2 scheme does not handle flows to retrieve an `accessToken`.

--- a/examples/src/github.ts
+++ b/examples/src/github.ts
@@ -14921,7 +14921,7 @@ export async function markdownRender(
 export async function markdownRenderRaw(
   ctx: r.Context<AuthMethods>,
   params: {},
-  body: any,
+  body: string,
 ): Promise<any | any> {
   const req = await ctx.createRequest({
     path: '/markdown/raw',
@@ -38875,7 +38875,7 @@ export async function activityListReposWatchedByUser(
 export async function metaGetZen(
   ctx: r.Context<AuthMethods>,
   params: {},
-): Promise<any> {
+): Promise<string> {
   const req = await ctx.createRequest({
     path: '/zen',
     params,

--- a/examples/src/petstore.ts
+++ b/examples/src/petstore.ts
@@ -325,7 +325,7 @@ export async function uploadFile(
     petId: number;
     additionalMetadata?: string;
   },
-  body: any,
+  body: Blob,
 ): Promise<ApiResponse> {
   const req = await ctx.createRequest({
     path: '/pet/{petId}/uploadImage',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "test:lint": "prettier . -c",
-    "test:eslint": "eslint .",
+    "test:eslint": "eslint --max-warnings 0 .",
     "test:types": "yarn workspaces foreach -ptv run test:types",
     "test:jest": "yarn workspaces foreach -ptv run test:jest"
   },

--- a/packages/typoas-generator/src/__tests__/__snapshots__/generator.spec.ts.snap
+++ b/packages/typoas-generator/src/__tests__/__snapshots__/generator.spec.ts.snap
@@ -177,7 +177,7 @@ export async function deletePet(ctx: r.Context<AuthMethods>, params: {
 export async function uploadFile(ctx: r.Context<AuthMethods>, params: {
     petId: number;
     additionalMetadata?: string;
-}, body: any): Promise<ApiResponse> {
+}, body: Blob): Promise<ApiResponse> {
     const req = await ctx.createRequest({
         path: '/pet/{petId}/uploadImage',
         params,

--- a/packages/typoas-generator/src/generator/api/operation/declaration.ts
+++ b/packages/typoas-generator/src/generator/api/operation/declaration.ts
@@ -1,8 +1,4 @@
-import {
-  isReferenceObject,
-  OperationObject,
-  ResponseObject,
-} from 'openapi3-ts';
+import { isReferenceObject, OperationObject } from 'openapi3-ts';
 import {
   factory,
   ParameterDeclaration,
@@ -24,6 +20,7 @@ import { GlobalParameters } from './types';
 import { createSchemaTypeFromResponse } from '../../components/responses';
 import { getSuccessResponses } from './response-processor';
 import { AUTH_TYPE_NAME } from '../security';
+import { getContentTypeSchema } from '../../utils/content-type';
 
 export function createOperationDeclaration(
   operation: OperationObject,
@@ -100,8 +97,8 @@ export function createOperationReturnType(
       return false;
     }
     return isEqual(
-      (a as ResponseObject).content?.['application/json'].schema,
-      (b as ResponseObject).content?.['application/json'].schema,
+      getContentTypeSchema(a.content, ctx),
+      getContentTypeSchema(b.content, ctx),
     );
   });
 

--- a/packages/typoas-generator/src/generator/api/operation/function-body.ts
+++ b/packages/typoas-generator/src/generator/api/operation/function-body.ts
@@ -11,6 +11,7 @@ import {
   Statement,
 } from 'typescript';
 import { createSchemaTransforms } from '../../utils/transformers';
+import { getContentTypeSchema } from '../../utils/content-type';
 
 export function createOperationBody(
   operation: OperationObject,
@@ -172,7 +173,7 @@ export function createOperationResponseHandlers(
         }
         res = ref.spec;
       }
-      const schema = res.content?.['application/json']?.schema;
+      const schema = getContentTypeSchema(res.content, ctx);
       if (!schema) {
         return null;
       }

--- a/packages/typoas-generator/src/generator/components/request-bodies.ts
+++ b/packages/typoas-generator/src/generator/components/request-bodies.ts
@@ -6,6 +6,7 @@ import {
   RequestBodyObject,
 } from 'openapi3-ts';
 import { createTypeFromSchema } from '../utils/types';
+import { getContentTypeSchema } from '../utils/content-type';
 
 export function createSchemaTypeFromRequestBody(
   requestBody: RequestBodyObject | ReferenceObject,
@@ -17,13 +18,13 @@ export function createSchemaTypeFromRequestBody(
       throw new Error(`$ref '${requestBody.$ref}' wasn't found`);
     }
     return createTypeFromSchema(
-      ref.spec.content['application/json']?.schema,
+      getContentTypeSchema(ref.spec.content, ctx),
       ctx,
     );
   }
 
   return createTypeFromSchema(
-    requestBody.content['application/json']?.schema,
+    getContentTypeSchema(requestBody.content, ctx),
     ctx,
   );
 }

--- a/packages/typoas-generator/src/generator/components/responses.ts
+++ b/packages/typoas-generator/src/generator/components/responses.ts
@@ -6,6 +6,7 @@ import {
   isReferenceObject,
 } from 'openapi3-ts';
 import { createTypeFromSchema } from '../utils/types';
+import { getContentTypeSchema } from '../utils/content-type';
 
 export function createSchemaTypeFromResponse(
   response: ResponseObject | ReferenceObject,
@@ -17,12 +18,9 @@ export function createSchemaTypeFromResponse(
       throw new Error(`$ref '${response.$ref}' wasn't found`);
     }
     return createTypeFromSchema(
-      ref.spec.content?.['application/json']?.schema,
+      getContentTypeSchema(ref.spec.content, ctx),
       ctx,
     );
   }
-  return createTypeFromSchema(
-    response.content?.['application/json']?.schema,
-    ctx,
-  );
+  return createTypeFromSchema(getContentTypeSchema(response.content, ctx), ctx);
 }

--- a/packages/typoas-generator/src/generator/utils/content-type.ts
+++ b/packages/typoas-generator/src/generator/utils/content-type.ts
@@ -1,0 +1,27 @@
+import { ContentObject, ReferenceObject, SchemaObject } from 'openapi3-ts';
+import { Context } from '../../context';
+
+// This key is a simple hack for the createTypeFromSchema function
+// for it to generate a Blob type that does not exist by default in json schema.
+export const TYPOAS_BLOB_TYPE_KEY = 'x-typoas-blob-type';
+
+export function getContentTypeSchema(
+  content: ContentObject | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ctx: Context,
+): ReferenceObject | SchemaObject | undefined {
+  if (!content) {
+    return undefined;
+  }
+  if (content['application/json']) {
+    return content['application/json'].schema;
+  }
+
+  if (content['text/plain']) {
+    return { type: 'string' };
+  }
+
+  if (content['application/octet-stream']) {
+    return { [TYPOAS_BLOB_TYPE_KEY]: true };
+  }
+}

--- a/packages/typoas-generator/src/generator/utils/types.ts
+++ b/packages/typoas-generator/src/generator/utils/types.ts
@@ -12,6 +12,7 @@ import {
   hasUnsupportedIdentifierChar,
   sanitizeTypeIdentifier,
 } from './operation-name';
+import { TYPOAS_BLOB_TYPE_KEY } from './content-type';
 
 export function createTypeFromSchema(
   schemaOrRef: SchemaObject | ReferenceObject | undefined,
@@ -33,6 +34,10 @@ export function createTypeFromSchema(
   }
 
   const schema = schemaOrRef as SchemaObject;
+
+  if (schema[TYPOAS_BLOB_TYPE_KEY]) {
+    return factory.createTypeReferenceNode(factory.createIdentifier('Blob'));
+  }
 
   let sEnum = null;
   if (schema.enum) {

--- a/packages/typoas-runtime/src/fetcher/types.ts
+++ b/packages/typoas-runtime/src/fetcher/types.ts
@@ -21,7 +21,7 @@ export type HttpFile = Blob & { readonly name: string };
 /**
  * Represents the body of an outgoing HTTP request.
  */
-export type RequestBody = undefined | string | FormData;
+export type RequestBody = undefined | string | FormData | Blob;
 
 export type QueryStyles =
   | 'form'

--- a/packages/typoas-runtime/src/utils.ts
+++ b/packages/typoas-runtime/src/utils.ts
@@ -62,3 +62,11 @@ export function applyTemplating(
 export function isHttpStatusValid(status: number): boolean {
   return status >= 200 && status < 400;
 }
+
+export function isBlob(data: unknown): data is Blob {
+  return data?.constructor.name === 'Blob';
+}
+
+export function isFormData(data: unknown): data is FormData {
+  return data?.constructor.name === 'FormData';
+}


### PR DESCRIPTION
Supersede #29 by adding support in the generator (generate Blob return types or body parameters where needed) and also improving support in runtime for binary content (both in request and response)

Fixes #12 
Fixes #29

cc @serybva