### PR TITLE
Do not add content-type header when formdata or blob body

### DIFF
--- a/packages/typoas-runtime/src/context/index.ts
+++ b/packages/typoas-runtime/src/context/index.ts
@@ -21,6 +21,7 @@ import {
   isCodeInRange,
   isFormData,
   isHttpStatusValid,
+  isURLSearchParams,
   serializeHeader,
   serializeParameter,
 } from '../utils';
@@ -75,19 +76,19 @@ export class Context<
       }
     }
     if (options.body !== undefined) {
-      if (isBlob(options.body)) {
-        requestContext.setHeaderParam(CONTENT_TYPE_HEADER, options.body.type);
-        requestContext.setBody(options.body);
-      } else if (isFormData(options.body)) {
-        requestContext.setHeaderParam(
-          CONTENT_TYPE_HEADER,
-          'multipart/form-data',
-        );
+      // Some body types should not have content-type header
+      // as it is set automatically by the browser
+      // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+      if (
+        isBlob(options.body) ||
+        isFormData(options.body) ||
+        isURLSearchParams(options.body)
+      ) {
         requestContext.setBody(options.body);
       } else {
         requestContext.setHeaderParam(
           CONTENT_TYPE_HEADER,
-          'application/json;charset=UTF-8',
+          options.contentType || 'application/json;charset=UTF-8',
         );
         requestContext.setBody(JSON.stringify(options.body));
       }

--- a/packages/typoas-runtime/src/context/types.ts
+++ b/packages/typoas-runtime/src/context/types.ts
@@ -43,6 +43,12 @@ export type CreateRequestParams = {
    * Name of the auth modes to be used.
    */
   auth?: string[];
+  /**
+   * Content type of the request.
+   * If not provided, it will set to application/json.
+   * If body is a FormData, Blob or URLSearchParams, it will not be set.
+   */
+  contentType?: string;
 };
 
 export type ContextParams<

--- a/packages/typoas-runtime/src/utils.ts
+++ b/packages/typoas-runtime/src/utils.ts
@@ -70,3 +70,7 @@ export function isBlob(data: unknown): data is Blob {
 export function isFormData(data: unknown): data is FormData {
   return data?.constructor.name === 'FormData';
 }
+
+export function isURLSearchParams(data: unknown): data is URLSearchParams {
+  return data?.constructor.name === 'URLSearchParams';
+}


### PR DESCRIPTION
Fix #40 

I looked into the fetch spec to know which content-type were automatically setup. I also added an option (runtime only) to specify the content type when creating request. It isn't used as is but can be used on generated content to override contentType.