### PR TITLE
fix(generator): Simplify sub schemas with type object

### DIFF
--- a/.yarn/versions/7cd52e87.yml
+++ b/.yarn/versions/7cd52e87.yml
@@ -1,0 +1,3 @@
+releases:
+  "@typoas/cli": patch
+  "@typoas/generator": patch

--- a/examples/src/github-sample.ts
+++ b/examples/src/github-sample.ts
@@ -2778,7 +2778,7 @@ export type MinimalRepository = {
     maintain?: boolean;
     triage?: boolean;
   };
-  template_repository?: (unknown & Repository) | null;
+  template_repository?: Repository | null;
   temp_clone_token?: string;
   delete_branch_on_merge?: boolean;
   subscribers_count?: number;
@@ -4286,7 +4286,7 @@ export type TeamRepository = {
    * @defaultValue true
    */
   allow_rebase_merge?: boolean;
-  template_repository?: (unknown & Repository) | null;
+  template_repository?: Repository | null;
   temp_clone_token?: string;
   /**
    * Whether to allow squash merges for pull requests.
@@ -4746,7 +4746,7 @@ export type FullRepository = {
    * @example true
    */
   allow_rebase_merge?: boolean;
-  template_repository?: (unknown & Repository) | null;
+  template_repository?: Repository | null;
   temp_clone_token?: string | null;
   /**
    * @example true
@@ -8540,30 +8540,28 @@ export type TimelineUnassignedIssueEvent = {
  * Timeline Event
  * Timeline Event
  */
-export type TimelineIssueEvents = unknown &
-  (
-    | LabeledIssueEvent
-    | UnlabeledIssueEvent
-    | MilestonedIssueEvent
-    | DemilestonedIssueEvent
-    | RenamedIssueEvent
-    | ReviewRequestedIssueEvent
-    | ReviewRequestRemovedIssueEvent
-    | ReviewDismissedIssueEvent
-    | LockedIssueEvent
-    | AddedToProjectIssueEvent
-    | MovedColumnInProjectIssueEvent
-    | RemovedFromProjectIssueEvent
-    | ConvertedNoteToIssueIssueEvent
-    | TimelineCommentEvent
-    | TimelineCrossReferencedEvent
-    | TimelineCommittedEvent
-    | TimelineReviewedEvent
-    | TimelineLineCommentedEvent
-    | TimelineCommitCommentedEvent
-    | TimelineAssignedIssueEvent
-    | TimelineUnassignedIssueEvent
-  );
+export type TimelineIssueEvents =
+  | LabeledIssueEvent
+  | UnlabeledIssueEvent
+  | MilestonedIssueEvent
+  | DemilestonedIssueEvent
+  | RenamedIssueEvent
+  | ReviewRequestedIssueEvent
+  | ReviewRequestRemovedIssueEvent
+  | ReviewDismissedIssueEvent
+  | LockedIssueEvent
+  | AddedToProjectIssueEvent
+  | MovedColumnInProjectIssueEvent
+  | RemovedFromProjectIssueEvent
+  | ConvertedNoteToIssueIssueEvent
+  | TimelineCommentEvent
+  | TimelineCrossReferencedEvent
+  | TimelineCommittedEvent
+  | TimelineReviewedEvent
+  | TimelineLineCommentedEvent
+  | TimelineCommitCommentedEvent
+  | TimelineAssignedIssueEvent
+  | TimelineUnassignedIssueEvent;
 /**
  * Deploy Key
  * An SSH key granting access to a single repository.

--- a/examples/src/github.ts
+++ b/examples/src/github.ts
@@ -8179,18 +8179,13 @@ export type RepositoryRulesetConditionsRepositoryPropertyTarget = {
  * The push rulesets conditions object does not require the `ref_name` property.
  * For repository policy rulesets, the conditions object should only contain the `repository_name`, the `repository_id`, or the `repository_property`.
  */
-export type OrgRulesetConditions = unknown &
-  (
-    | (unknown &
-        (RepositoryRulesetConditions &
-          RepositoryRulesetConditionsRepositoryNameTarget))
-    | (unknown &
-        (RepositoryRulesetConditions &
-          RepositoryRulesetConditionsRepositoryIdTarget))
-    | (unknown &
-        (RepositoryRulesetConditions &
-          RepositoryRulesetConditionsRepositoryPropertyTarget))
-  );
+export type OrgRulesetConditions =
+  | (RepositoryRulesetConditions &
+      RepositoryRulesetConditionsRepositoryNameTarget)
+  | (RepositoryRulesetConditions &
+      RepositoryRulesetConditionsRepositoryIdTarget)
+  | (RepositoryRulesetConditions &
+      RepositoryRulesetConditionsRepositoryPropertyTarget);
 /**
  * creation
  * Only allow users with bypass permission to create matching refs.
@@ -8593,62 +8588,60 @@ export type RepositoryRuleCodeScanning = {
  * Repository Rule
  * A repository rule.
  */
-export type RepositoryRule = unknown &
-  (
-    | RepositoryRuleCreation
-    | RepositoryRuleUpdate
-    | RepositoryRuleDeletion
-    | RepositoryRuleRequiredLinearHistory
-    | RepositoryRuleMergeQueue
-    | RepositoryRuleRequiredDeployments
-    | RepositoryRuleRequiredSignatures
-    | RepositoryRulePullRequest
-    | RepositoryRuleRequiredStatusChecks
-    | RepositoryRuleNonFastForward
-    | RepositoryRuleCommitMessagePattern
-    | RepositoryRuleCommitAuthorEmailPattern
-    | RepositoryRuleCommitterEmailPattern
-    | RepositoryRuleBranchNamePattern
-    | RepositoryRuleTagNamePattern
-    | {
-        type: 'file_path_restriction';
-        parameters?: {
-          /**
-           * The file paths that are restricted from being pushed to the commit graph.
-           */
-          restricted_file_paths: string[];
-        };
-      }
-    | {
-        type: 'max_file_path_length';
-        parameters?: {
-          /**
-           * The maximum amount of characters allowed in file paths
-           */
-          max_file_path_length: number;
-        };
-      }
-    | {
-        type: 'file_extension_restriction';
-        parameters?: {
-          /**
-           * The file extensions that are restricted from being pushed to the commit graph.
-           */
-          restricted_file_extensions: string[];
-        };
-      }
-    | {
-        type: 'max_file_size';
-        parameters?: {
-          /**
-           * The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).
-           */
-          max_file_size: number;
-        };
-      }
-    | RepositoryRuleWorkflows
-    | RepositoryRuleCodeScanning
-  );
+export type RepositoryRule =
+  | RepositoryRuleCreation
+  | RepositoryRuleUpdate
+  | RepositoryRuleDeletion
+  | RepositoryRuleRequiredLinearHistory
+  | RepositoryRuleMergeQueue
+  | RepositoryRuleRequiredDeployments
+  | RepositoryRuleRequiredSignatures
+  | RepositoryRulePullRequest
+  | RepositoryRuleRequiredStatusChecks
+  | RepositoryRuleNonFastForward
+  | RepositoryRuleCommitMessagePattern
+  | RepositoryRuleCommitAuthorEmailPattern
+  | RepositoryRuleCommitterEmailPattern
+  | RepositoryRuleBranchNamePattern
+  | RepositoryRuleTagNamePattern
+  | {
+      type: 'file_path_restriction';
+      parameters?: {
+        /**
+         * The file paths that are restricted from being pushed to the commit graph.
+         */
+        restricted_file_paths: string[];
+      };
+    }
+  | {
+      type: 'max_file_path_length';
+      parameters?: {
+        /**
+         * The maximum amount of characters allowed in file paths
+         */
+        max_file_path_length: number;
+      };
+    }
+  | {
+      type: 'file_extension_restriction';
+      parameters?: {
+        /**
+         * The file extensions that are restricted from being pushed to the commit graph.
+         */
+        restricted_file_extensions: string[];
+      };
+    }
+  | {
+      type: 'max_file_size';
+      parameters?: {
+        /**
+         * The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).
+         */
+        max_file_size: number;
+      };
+    }
+  | RepositoryRuleWorkflows
+  | RepositoryRuleCodeScanning;
 /**
  * Repository ruleset
  * A set of rules to apply when specified conditions are met.
@@ -15499,31 +15492,29 @@ export type StateChangeIssueEvent = {
  * Timeline Event
  * Timeline Event
  */
-export type TimelineIssueEvents = unknown &
-  (
-    | LabeledIssueEvent
-    | UnlabeledIssueEvent
-    | MilestonedIssueEvent
-    | DemilestonedIssueEvent
-    | RenamedIssueEvent
-    | ReviewRequestedIssueEvent
-    | ReviewRequestRemovedIssueEvent
-    | ReviewDismissedIssueEvent
-    | LockedIssueEvent
-    | AddedToProjectIssueEvent
-    | MovedColumnInProjectIssueEvent
-    | RemovedFromProjectIssueEvent
-    | ConvertedNoteToIssueIssueEvent
-    | TimelineCommentEvent
-    | TimelineCrossReferencedEvent
-    | TimelineCommittedEvent
-    | TimelineReviewedEvent
-    | TimelineLineCommentedEvent
-    | TimelineCommitCommentedEvent
-    | TimelineAssignedIssueEvent
-    | TimelineUnassignedIssueEvent
-    | StateChangeIssueEvent
-  );
+export type TimelineIssueEvents =
+  | LabeledIssueEvent
+  | UnlabeledIssueEvent
+  | MilestonedIssueEvent
+  | DemilestonedIssueEvent
+  | RenamedIssueEvent
+  | ReviewRequestedIssueEvent
+  | ReviewRequestRemovedIssueEvent
+  | ReviewDismissedIssueEvent
+  | LockedIssueEvent
+  | AddedToProjectIssueEvent
+  | MovedColumnInProjectIssueEvent
+  | RemovedFromProjectIssueEvent
+  | ConvertedNoteToIssueIssueEvent
+  | TimelineCommentEvent
+  | TimelineCrossReferencedEvent
+  | TimelineCommittedEvent
+  | TimelineReviewedEvent
+  | TimelineLineCommentedEvent
+  | TimelineCommitCommentedEvent
+  | TimelineAssignedIssueEvent
+  | TimelineUnassignedIssueEvent
+  | StateChangeIssueEvent;
 /**
  * Deploy Key
  * An SSH key granting access to a single repository.
@@ -16348,26 +16339,24 @@ export type RepositoryRuleRulesetInfo = unknown;
  * Repository Rule
  * A repository rule with ruleset details.
  */
-export type RepositoryRuleDetailed = unknown &
-  (
-    | (RepositoryRuleCreation & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleUpdate & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleDeletion & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleRequiredLinearHistory & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleMergeQueue & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleRequiredDeployments & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleRequiredSignatures & RepositoryRuleRulesetInfo)
-    | (RepositoryRulePullRequest & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleRequiredStatusChecks & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleNonFastForward & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleCommitMessagePattern & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleCommitAuthorEmailPattern & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleCommitterEmailPattern & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleBranchNamePattern & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleTagNamePattern & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleWorkflows & RepositoryRuleRulesetInfo)
-    | (RepositoryRuleCodeScanning & RepositoryRuleRulesetInfo)
-  );
+export type RepositoryRuleDetailed =
+  | (RepositoryRuleCreation & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleUpdate & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleDeletion & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleRequiredLinearHistory & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleMergeQueue & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleRequiredDeployments & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleRequiredSignatures & RepositoryRuleRulesetInfo)
+  | (RepositoryRulePullRequest & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleRequiredStatusChecks & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleNonFastForward & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleCommitMessagePattern & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleCommitAuthorEmailPattern & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleCommitterEmailPattern & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleBranchNamePattern & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleTagNamePattern & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleWorkflows & RepositoryRuleRulesetInfo)
+  | (RepositoryRuleCodeScanning & RepositoryRuleRulesetInfo);
 export type SecretScanningAlert = {
   number?: AlertNumber;
   created_at?: AlertCreatedAt;

--- a/packages/typoas-generator/src/generator/utils/types.ts
+++ b/packages/typoas-generator/src/generator/utils/types.ts
@@ -221,10 +221,18 @@ export function createTypeFromSchema(
   if (subSchemaType) {
     // allOf/oneOf/anyOf can be used with a schema that has already a type
     // In our case, we only care about 'object' types as others wouldn't add typings information
-    if (
+    // We also filter out the cases where the schema only defines the object type (no properties, etc.)
+
+    const isObject =
       schema.type === 'object' ||
-      (Array.isArray(schema.type) && schema.type.includes('object'))
-    ) {
+      (Array.isArray(schema.type) && schema.type.includes('object'));
+    const isComplexObject =
+      schema.properties ||
+      schema.additionalProperties ||
+      schema.patternProperties ||
+      schema.unevaluatedProperties;
+
+    if (isObject && isComplexObject) {
       node = factory.createIntersectionTypeNode([node, subSchemaType]);
     } else {
       node = subSchemaType;


### PR DESCRIPTION
There are still some cases where we generate unknown stuff (e.g. Github). This is because they are not using correct json schemas.